### PR TITLE
Simplified and rationalised mcp server and reconfigured to use stream…

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,7 +2,7 @@
     "servers": {
         "PYLINT_MCP": {
             "type": "sse",
-            "url": "http://localhost:8000/sse"
+            "url": "http://localhost:8000/mcp"
         }
     }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /app
 RUN uv sync --frozen --no-cache
 
 # Run the application.
-CMD ["/app/.venv/bin/fastapi", "run", "/app/main.py", "--port", "8000", "--host", "0.0.0.0"]
+CMD ["uv", "run", "src/main.py"]
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Pylint MCP Server
 
-A Model Context Protocol (MCP) server that provides comprehensive Python code analysis capabilities through MCP tools, including Pylint, Symilar, and Pyreverse.
+A Model Context Protocol (MCP) server that provides comprehensive Python code analysis capabilities through MCP tools, including Pylint, Symilar, and Pyreverse. It runs using streamable-http, which is supported by MS Teams Apps, and other popular MCP clients such as Github Copilot.
 
 ## Overview
 
@@ -52,7 +52,18 @@ src/
    uv run fastapi dev main.py
    ```
 
-3. **Connect via MCP**: Configure your MCP client to connect to `http://localhost:8000/sse`
+3. **Connect via MCP**: Configure your MCP client to connect to `http://localhost:8000/mcp`
+
+If using Github Copilot, you can create a folder in your PROJECT ROOT DIRECTORY called .vscode, and then put an mcp.json file in there. Then, paste the following into that:
+{
+    "servers": {
+        "PYLINT_MCP": {
+            "type": "sse",
+            "url": "http://localhost:8000/mcp"
+        }
+    }
+}
+
 
 ## Available Tools
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,36 +1,8 @@
-from fastapi import FastAPI, Request, Depends
-from mcp.server.sse import SseServerTransport
-from starlette.routing import Mount
-import uvicorn
-import dotenv
 from shared_mcp_object import mcp, register_all_tools
 
-dotenv.load_dotenv()
-
 tools_count = register_all_tools()
-print(f"Registered tools from {tools_count} modules")
-
-app = FastAPI(docs_url=None, redoc_url=None)
-sse = SseServerTransport("/messages/")
-app.router.routes.append(Mount("/messages", app=sse.handle_post_message))
-
-
-@app.get("/sse", tags=["MCP"])
-async def handle_sse(request: Request):
-    
-    async with sse.connect_sse(request.scope, request.receive, request._send) as (
-        read_stream,
-        write_stream,
-    ):
-        init_options = mcp._mcp_server.create_initialization_options()
-
-        await mcp._mcp_server.run(
-            read_stream,
-            write_stream,
-            init_options,
-        )
-
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    print(f"Registered tools from {tools_count} modules")
+    mcp.run(transport='streamable-http')
     

--- a/src/shared_mcp_object.py
+++ b/src/shared_mcp_object.py
@@ -2,7 +2,7 @@ import os
 import importlib
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("PYLINT_MCP")
+mcp = FastMCP("PYLINT_MCP", host="0.0.0.0", port=8000, mount_path="/mcp")
 
 RESOURCES_DIR = os.path.join(os.path.dirname(__file__), 'resources')
 TOOLS_DIR = os.path.join(os.path.dirname(__file__), 'tools')


### PR DESCRIPTION
…able-http for wider client compatibility, namely with MS teams

- Changed main.py to have a simplified server
- Updated endpoint mount to /mcp
- Updated readme with more guidance on how to run the server